### PR TITLE
Fixes deprecation warnings raised in tests

### DIFF
--- a/app/models/generic_file.rb
+++ b/app/models/generic_file.rb
@@ -15,8 +15,8 @@ class GenericFile < ActiveFedora::Base
   has_metadata name: 'descMetadata',     type: GenericFileRdfDatastream
   has_metadata name: 'workflowMetadata', type: WorkflowRdfDatastream
 
-  has_attributes [:workflows, :workflows_attributes], datastream: 'workflowMetadata', multiple: true
-  has_attributes GenericFileRdfDatastream.fields,     datastream: 'descMetadata',     multiple: true
+  has_attributes :workflows, :workflows_attributes,  datastream: 'workflowMetadata', multiple: true
+  has_attributes *GenericFileRdfDatastream.fields,   datastream: 'descMetadata',     multiple: true
   
   has_and_belongs_to_many :authors,           property: :has_author,           class_name: 'Person'
   has_and_belongs_to_many :contributors,      property: :has_contributor,      class_name: 'Person'

--- a/app/models/generic_file.rb
+++ b/app/models/generic_file.rb
@@ -1,7 +1,7 @@
-require "datastreams/workflow_rdf_datastream"
-require "datastreams/generic_file_rdf_datastream"
-require "person"
-require "rdf"
+require 'datastreams/workflow_rdf_datastream'
+require 'datastreams/generic_file_rdf_datastream'
+require 'person'
+require 'rdf'
 
 class GenericFile < ActiveFedora::Base
   include Sufia::GenericFile
@@ -12,15 +12,15 @@ class GenericFile < ActiveFedora::Base
   
   before_create :initialize_submission_workflow
 
-  has_metadata :name => "descMetadata", :type => GenericFileRdfDatastream
-  has_metadata :name => "workflowMetadata", :type => WorkflowRdfDatastream
+  has_metadata name: 'descMetadata',     type: GenericFileRdfDatastream
+  has_metadata name: 'workflowMetadata', type: WorkflowRdfDatastream
 
-  delegate_to "workflowMetadata",  [:workflows, :workflows_attributes], multiple: true
-  delegate_to "descMetadata", GenericFileRdfDatastream.fields, multiple: true
-
-  has_and_belongs_to_many :authors, :property=> :has_author, :class_name=>"Person"
-  has_and_belongs_to_many :contributors, :property=> :has_contributor, :class_name=>"Person"
-  has_and_belongs_to_many :copyright_holders, :property=> :has_copyright_holder, :class_name=>"Person"
+  has_attributes [:workflows, :workflows_attributes], datastream: 'workflowMetadata', multiple: true
+  has_attributes GenericFileRdfDatastream.fields,     datastream: 'descMetadata',     multiple: true
+  
+  has_and_belongs_to_many :authors,           property: :has_author,           class_name: 'Person'
+  has_and_belongs_to_many :contributors,      property: :has_contributor,      class_name: 'Person'
+  has_and_belongs_to_many :copyright_holders, property: :has_copyright_holder, class_name: 'Person'
 
   #def to_solr(solr_doc={}, opts={})
   #  super(solr_doc, opts)
@@ -33,7 +33,7 @@ class GenericFile < ActiveFedora::Base
   
   def initialize_submission_workflow
     if self.workflows.empty?  
-      wf = self.workflows.build(identifier:"MediatedSubmission")
+      wf = self.workflows.build(identifier: "MediatedSubmission")
       wf.entries.build(status: Sufia.config.draft_status, date: Time.now.to_s)
     end
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,9 +1,16 @@
-require "datastreams/person_rdf_datastream"
-require "rdf"
+require 'datastreams/person_rdf_datastream'
+require 'rdf'
 
 class Person < ActiveFedora::Base
   #include Sufia::GenericFile
-  has_metadata :name => "descMetadata", :type => PersonRdfDatastream
-  delegate_to :descMetadata, [:first_name, :last_name, :display_name, :name, :title, :email, 
-  :website, :institution, :faculty, :oxford_college, :research_group, :webauth, :identifier]
+  has_metadata name: 'descMetadata', type: PersonRdfDatastream
+  delegate_to(
+    :descMetadata, 
+    [
+      :first_name, :last_name, :display_name, :name, :title, :email, 
+      :website, :institution, :faculty, :oxford_college, :research_group, 
+      :webauth, :identifier
+    ],
+    multiple: true
+  )
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -4,13 +4,12 @@ require 'rdf'
 class Person < ActiveFedora::Base
   #include Sufia::GenericFile
   has_metadata name: 'descMetadata', type: PersonRdfDatastream
-  delegate_to(
-    :descMetadata, 
-    [
-      :first_name, :last_name, :display_name, :name, :title, :email, 
-      :website, :institution, :faculty, :oxford_college, :research_group, 
-      :webauth, :identifier
-    ],
+  
+  has_attributes(
+    :first_name, :last_name, :display_name, :name, :title, :email, :website, 
+    :institution, :faculty, :oxford_college, :research_group, :webauth, :identifier,
+    datastream: :descMetadata, 
     multiple: true
   )
+  
 end

--- a/app/views/shared/_progress_tracker.html.erb
+++ b/app/views/shared/_progress_tracker.html.erb
@@ -30,31 +30,31 @@
         <div data-progress-link="citation" class="cat cat-citation">
           <span>Citation</span>
           <div class="bar">
-            <div class="percentage" style="width: <%= progress[:citation] %>%"></div>
+            <div class="percentage" style="width: <%= progress[:citation] %>"></div>
           </div>
         </div>
         <div data-progress-link="discoverability" class="cat cat-discoverability">
           <span>Discoverability</span>
           <div class="bar">
-            <div class="percentage" style="width: <%= progress[:discoverability] %>%"></div>
+            <div class="percentage" style="width: <%= progress[:discoverability] %>"></div>
           </div>
         </div>
         <div data-progress-link="funder" class="cat cat-funder">
           <span>Funder Compliance</span>
           <div class="bar">
-            <div class="percentage" style="width: <%= progress[:funder] %>%"></div>
+            <div class="percentage" style="width: <%= progress[:funder] %>"></div>
           </div>
         </div>
         <div data-progress-link="documentation" class="cat cat-documentation">
           <span>Documentation, access &amp; re-use</span>
           <div class="bar">
-            <div class="percentage" style="width: <%= progress[:documentation] %>%"></div>
+            <div class="percentage" style="width: <%= progress[:documentation] %>"></div>
           </div>
         </div>
         <div data-progress-link="preservation" class="cat cat-preservation">
           <span>Preservation</span>
           <div class="bar">
-            <div class="percentage" style="width: <%= progress[:documentation] %>%"></div>
+            <div class="percentage" style="width: <%= progress[:documentation] %>"></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
The use of delegate_to in active_fedora models is replaced here with has_attributes.

Note that after these warnings have been corrected, a new deprecation warning appears:

    DEPRECATION WARNING: Blacklight.solr is deprecated and will be removed in Blacklight 5.0.

However, there is [evidence that this deprecation was later withdrawn](https://github.com/sul-dlss/hydrus/issues/12), so this has been left unchanged.