### PR TITLE
<1> Fixed: Hydra: Error in journal article deposit form; <2> added additional help text; <3> made a conditional role check to display 'access conditions' on the deposit form ; <4> https://trello.com/c/6aryW2kA/117-thesis-step-6-access-condition-for-the-catalogue-record <5> https://trello.com/c/EuLhAxL8/116-thesis-2-about-your-award-lts-date

### DIFF
--- a/app/views/shared/embargo/_embargo_fields_edit.html.erb
+++ b/app/views/shared/embargo/_embargo_fields_edit.html.erb
@@ -34,26 +34,38 @@
   <% end %>
   
     <fieldset class="small-text">
-      <% if embargo_type == "metadata" #Field required for catalogue record %>
+
+        <% if embargo_type == "metadata" #Field required for catalogue record %>
         <% req_class = "required" %>
       <% else %>
         <% req_class = "" %>
       <% end %>
+
+      <% if can? :review, :all %>
+         <% open_access_checked = (accessRights[0].embargoStatus[0] == "Open access") %>
+      <% else %>
+         <% open_access_checked = true %>
+      <% end %>
+
       <label>
-        <%= f_a.radio_button :embargoStatus, "Open access", :checked => (accessRights[0].embargoStatus[0] == "Open access"),
-          data: {"progress" => "documentation"}, :class => req_class  %>
+        <%= f_a.radio_button :embargoStatus, "Open access", :checked => open_access_checked ,
+                         data: {"progress" => "documentation"}, :class => req_class  %>
         <span></span>Yes
       </label>
-      <label panel='dataset-embargo-<%= panel_id %>'>
-        <%= f_a.radio_button :embargoStatus, "Embargoed", :checked => (accessRights[0].embargoStatus[0] == "Embargoed"),
-          data: {"progress" => "documentation"}, :class => "#{req_class} embargoed" %>
-        <span></span>After a certain period
-      </label>
-      <label>
-        <%= f_a.radio_button :embargoStatus, "Closed access", :checked => (accessRights[0].embargoStatus[0] == "Closed access"),
-          data: {"progress" => "documentation"}, :class => "#{req_class}" %>
-        <span></span>No
-      </label>
+
+      <% if can? :review, :all %>
+        <label panel='dataset-embargo-<%= panel_id %>'>
+          <%= f_a.radio_button :embargoStatus, "Embargoed", :checked => (accessRights[0].embargoStatus[0] == "Embargoed"),
+            data: {"progress" => "documentation"}, :class => "#{req_class} embargoed" %>
+          <span></span>After a certain period
+        </label>
+        <label>
+          <%= f_a.radio_button :embargoStatus, "Closed access", :checked => (accessRights[0].embargoStatus[0] == "Closed access"),
+            data: {"progress" => "documentation"}, :class => "#{req_class}" %>
+          <span></span>No
+        </label>
+      <% end %>
+
     </fieldset>
   
     <% if embargo_type == "metadata" %>
@@ -63,8 +75,9 @@
               Please let us know which you would prefer." %>
       <% elsif @model == "thesis" %>
         <% desc = "The catalogue record for your thesis will normally be made publicly visible and openly accessible, even if your thesis is embargoed.
-              In a small number of exceptional cases, it may be necessary to embargo and hide from public view the record as well as the files.
-               If you require the record page or abstract to be embargoed in addition to your thesis file please complete a request for dispensation from consultation." %>
+                   In a small number of exceptional cases, it may be necessary to embargo and hide from public view the record as well as the files.
+                   If you require the record page or abstract to be embargoed in addition to your thesis file please complete a request for dispensation
+                   from consultation and enter details in the section above." %>
       <% else %>
         <% desc = "The catalogue record for your publication will normally be made publicly visible and openly accessible, even if the publication is embargoed.
               In a small number of exceptional cases, it may be necessary to embargo and hide from public view the record as well as the files.

--- a/app/views/shared/upload/_files_form.html.erb
+++ b/app/views/shared/upload/_files_form.html.erb
@@ -1,10 +1,11 @@
 <h4>Select files to upload</h4>
-<p>
-    <% if @model == "thesis" %>
-        Two copies of your thesis should be submitted to the research archive. An archive version and a dissemination version. For more information about what
-to deposit to the archive please see the <a href="http://ox.libguides.com/what_to_deposit"  target="_blank">Digital theses and ORA LibGuide</a>.
-    <% end %>
-</p>
+<% if @model == "thesis" %>
+    <p>
+            Two copies of your thesis should be submitted to the research archive. An archive version and a dissemination version. For more information about what
+    to deposit to the archive please see the <a href="http://ox.libguides.com/what_to_deposit"  target="_blank">Digital theses and ORA LibGuide</a>.
+
+    </p>
+<% end %>
 <%= render partial: 'shared/upload/tos_checkbox' %>
 <%= render partial: 'shared/upload/alerts', :locals => { :editpath => editpath } %>
 <%= form_for(record, :html => {:multipart => true, :id => 'fileupload'}) do |f| %>

--- a/app/views/shared/upload/_files_form.html.erb
+++ b/app/views/shared/upload/_files_form.html.erb
@@ -1,6 +1,10 @@
 <h4>Select files to upload</h4>
-<p>Two copies of your thesis should be submitted to the research archive. An archive version and a dissemination version. For more information about what 
-to deposit to the archive please see the <a href="http://ox.libguides.com/what_to_deposit"  target="_blank">Digital theses and ORA LibGuide</a>.</p>
+<p>
+    <% if @model == "thesis" %>
+        Two copies of your thesis should be submitted to the research archive. An archive version and a dissemination version. For more information about what
+to deposit to the archive please see the <a href="http://ox.libguides.com/what_to_deposit"  target="_blank">Digital theses and ORA LibGuide</a>.
+    <% end %>
+</p>
 <%= render partial: 'shared/upload/tos_checkbox' %>
 <%= render partial: 'shared/upload/alerts', :locals => { :editpath => editpath } %>
 <%= form_for(record, :html => {:multipart => true, :id => 'fileupload'}) do |f| %>

--- a/app/views/static/help.html.erb
+++ b/app/views/static/help.html.erb
@@ -24,6 +24,10 @@ limitations under the License.
     <a href="http://libguides.bodleian.ox.ac.uk/ora-data">http://libguides.bodleian.ox.ac.uk/ora-data</a>.
 </p>
 <p>
+    For a step-by-step guide to creating records and depositing datasets in ORA-Data, please see:
+    <a href="http://www.bodleian.ox.ac.uk/__data/assets/pdf_file/0005/193325/How-to-deposit-in-ORA-Data.pdf">http://www.bodleian.ox.ac.uk/__data/assets/pdf_file/0005/193325/How-to-deposit-in-ORA-Data.pdf</a>.
+</p>
+<p>
     For detailed information and guidance about using ORA for publications, theses and other works, see the ORA
     Help & Information pages at <a href="http://www.bodleian.ox.ac.uk/ora">http://www.bodleian.ox.ac.uk/ora</a>.
 </p>

--- a/app/views/theses/_form.html.erb
+++ b/app/views/theses/_form.html.erb
@@ -157,7 +157,9 @@
           <%= render partial: "admin_fields_edit", :locals => { :f => f, :thesis => @thesis } %>
         </div>
         <%= render partial: 'shared/file_info_fields_edit', :locals => { :f => f, :article => @thesis } %>
-        <%= render partial: 'shared/embargo/embargo_fields_edit', :locals => { :f => f, :accessRights => @thesis.accessRights, :embargo_type => "metadata" } %>
+        <% if can? :review, :all %>
+          <%= render partial: 'shared/embargo/embargo_fields_edit', :locals => { :f => f, :accessRights => @thesis.accessRights, :embargo_type => "metadata" } %>
+        <% end %>
       </div>
 
         <%= render partial: 'navigate', locals: { main_text: 'Continue to Step 7', sub_text: 'Review workflow' } %>

--- a/app/views/theses/_form.html.erb
+++ b/app/views/theses/_form.html.erb
@@ -157,9 +157,7 @@
           <%= render partial: "admin_fields_edit", :locals => { :f => f, :thesis => @thesis } %>
         </div>
         <%= render partial: 'shared/file_info_fields_edit', :locals => { :f => f, :article => @thesis } %>
-        <% if can? :review, :all %>
-          <%= render partial: 'shared/embargo/embargo_fields_edit', :locals => { :f => f, :accessRights => @thesis.accessRights, :embargo_type => "metadata" } %>
-        <% end %>
+        <%= render partial: 'shared/embargo/embargo_fields_edit', :locals => { :f => f, :accessRights => @thesis.accessRights, :embargo_type => "metadata" } %>
       </div>
 
         <%= render partial: 'navigate', locals: { main_text: 'Continue to Step 7', sub_text: 'Review workflow' } %>

--- a/app/views/theses/_thesis_details_edit.html.erb
+++ b/app/views/theses/_thesis_details_edit.html.erb
@@ -1,7 +1,7 @@
 <div class="fieldset">
   <p class="small">Type of degree</p>
   <%= f.select( :degreeName, options_for_select(Sufia.config.thesis_degree_types, selected: @thesis.degreeName.first), { include_blank: 'Select a degree type' }, data: {"progress" => "discoverability"}   ) %>
-  <div class="hidden-form"> 
+  <div class="hidden-form">
 	  <p class="small">Level of degree</p>
 		<%= f.text_field :degreeType, value: @thesis.degreeType.first, readonly: true, style: 'width: 20%' %>
   </div>
@@ -9,6 +9,9 @@
 
 
 <div class="fieldset">
-  <p class="small">Year leave to supplicate granted</p>
+  <p class="small">Date your leave to supplicate (LTS) was granted</p>
   <%= f.date_field :dateOfAward, value: @thesis.dateOfAward.first, style: 'width: 20%', data: {"progress" => "discoverability"} %>
+  <% desc = "Please provide the date leave to supplicate was granted (DD/MM/YY), details can be found on your LTS letter or student record in eVision" %>
+  <% tipTitle = "LTS date" %>
+  <%= render partial: '/shared/tooltip', :locals => {:tipType => "discoverability" , :tipTitle => tipTitle , :tipDescription => desc } %>
 </div>

--- a/lib/ora/sample.rb
+++ b/lib/ora/sample.rb
@@ -1,0 +1,17 @@
+require '/home/oraadmin/ora-hydra/lib/ora/add_large_file.rb'
+include Ora
+
+
+module Ora
+
+  module_function
+
+  # Adds a large file to the UUID of the specified record in ORA
+  # Params:
+
+  def addLargeFiletoUUID(pid, filepath)
+    addLargeFile(pid,filepath)
+    print "File Uploaded successfully!"
+  end #addLargeFiletoUUID
+
+end #module ORA


### PR DESCRIPTION
Trello ticket:  https://trello.com/c/SQXq5RHf/112-hydra-error-in-journal-article-deposit-form
Fix:  File upload help text which was earlier meant to be added to theses, was appearing on both articles and datasets. Now its been fixed to appear only on theses.

Trello ticket: https://trello.com/c/CAsTGds2/113-can-we-add-a-further-paragraph-to-the-help-page-at-https-oradeposit-bodleian-ox-ac-uk-help
Fix: Added additional help text as para 3

Trello ticket: https://trello.com/c/uHkWO1Cr/103-section-6-making-your-thesis-available-access-conditions-for-the-catalogue-record-should-not-be-visible-to-depositors
Fix: Added conditional check for type of user to display the 'Access Conditions' sections in the deposit form.

Trello ticket:  https://trello.com/c/6aryW2kA/117-thesis-step-6-access-condition-for-the-catalogue-record
Fix:  On deposit thesis from, the access conditions now defaults to 'yes' and removed other choices. However, the other choices are still available for the reviewer

Trello ticket: https://trello.com/c/EuLhAxL8/116-thesis-2-about-your-award-lts-date
Fix:  Theses : Changed the text in 'About your award - LTS date' and added tooltip with the required help text.