### PR TITLE
The ora.js was restricting the embargo date range shown. This cap is now removed.

### DIFF
--- a/app/assets/javascripts/ora.js
+++ b/app/assets/javascripts/ora.js
@@ -262,9 +262,7 @@ $(function() {
     if ($(this).attr("name").match(/dateAccepted/)) {
       options.maxDate = 0;
     }
-    if ($(this).attr("name").match(/embargoDate/)) {
-      options.minDate = 0;
-    }
+
     $(this).datepicker(options).attr("type", "text");
   });
 


### PR DESCRIPTION

Trello ticket:
	https://trello.com/c/Tr99D5VS/126-thesis-embargo-date-calendar-range-does-not-go-retrospective


Description:
	In Access conditions for files (step 6) > Edit details/embargo for file > After a certain period > Embargo period > starting from date > calendar does not give option to go back from current month. 


Fix:
	The ora.js was restricting the range of the embargo date being shown. This cap is now removed for the embargo date so that one can select dates before today's date or the publishing date.