### PR TITLE
Added a new text field 'comment' to articles, datasets and theses with access being 'public'. Also , removed the Duration from display that was most recently addedunder the 'Access condition for files' which would otherwise display 'false'(Boolean)

### DIFF
--- a/app/models/datastreams/article_rdf_datastream.rb
+++ b/app/models/datastreams/article_rdf_datastream.rb
@@ -19,7 +19,7 @@ require 'fields/publication_activity'
 class ArticleRdfDatastream < ActiveFedora::NtriplesRDFDatastream
   #include ModelHelper
 
-  attr_accessor :title, :subtitle, :abstract, :subject, :keyword, :worktype, :medium, :language, :publicationStatus, :reviewStatus, :license, :dateCopyrighted, :rightsHolder, :rights, :rightsActivity, :creation, :funding, :publication
+  attr_accessor :title, :subtitle, :abstract, :subject, :keyword, :worktype, :medium, :language, :publicationStatus, :reviewStatus, :license, :dateCopyrighted, :rightsHolder, :rights, :rightsActivity, :creation, :funding, :publication, :comments
 
   rdf_type rdf_type RDF::PROV.Entity
   map_predicates do |map|
@@ -63,7 +63,7 @@ class ArticleRdfDatastream < ActiveFedora::NtriplesRDFDatastream
     # TODO: Nested attributes using Prov
     #-- source --
     # TODO: Nested attributes of name, homepage and uri - one to many
-
+    map.comments(:to => "description", :in => RDF::DC)
   end
   accepts_nested_attributes_for :language
   accepts_nested_attributes_for :subject

--- a/app/models/datastreams/dataset_rdf_datastream.rb
+++ b/app/models/datastreams/dataset_rdf_datastream.rb
@@ -22,7 +22,7 @@ require 'fields/location'
 class DatasetRdfDatastream < ActiveFedora::NtriplesRDFDatastream
   #include ModelHelper
 
-  attr_accessor :title, :subtitle, :abstract, :subject, :keyword, :worktype, :language, :license, :dateCopyrighted, :rightsHolder, :rights, :rightsActivity, :creation, :funding, :publication
+  attr_accessor :title, :subtitle, :abstract, :subject, :keyword, :worktype, :language, :license, :dateCopyrighted, :rightsHolder, :rights, :rightsActivity, :creation, :funding, :publication, :comments
 
   rdf_type rdf_type RDF::PROV.Entity
   map_predicates do |map|
@@ -74,6 +74,7 @@ class DatasetRdfDatastream < ActiveFedora::NtriplesRDFDatastream
     map.publication(:to => "hadPublicationActivity", :in => RDF::ORA, class_name:"PublicationActivity")
     #-- source --
     # TODO: Nested attributes of name, homepage and uri - one to many
+    map.comments(:to => "description", :in => RDF::DC)
 
   end
   accepts_nested_attributes_for :subject

--- a/app/models/datastreams/thesis_rdf_datastream.rb
+++ b/app/models/datastreams/thesis_rdf_datastream.rb
@@ -12,7 +12,7 @@ require 'fields/publication_activity'
 
 class ThesisRdfDatastream < ActiveFedora::NtriplesRDFDatastream
 
-  attr_accessor :title, :subtitle, :abstract, :subject, :keyword, :worktype, :medium, :language, :dateCopyrighted, :rightsHolder, :rights, :rightsActivity, :license, :creation, :publication, :funding
+  attr_accessor :title, :subtitle, :abstract, :subject, :keyword, :worktype, :medium, :language, :dateCopyrighted, :rightsHolder, :rights, :rightsActivity, :license, :creation, :publication, :funding, :comments
 
   rdf_type rdf_type RDF::PROV.Entity
   map_predicates do |map|
@@ -45,7 +45,8 @@ class ThesisRdfDatastream < ActiveFedora::NtriplesRDFDatastream
     map.dispensationSelect(:in => RDF::ORA)
     map.dispensationPeriodStartFromDate(:in => RDF::ORA)
     map.dispensationPeriodPermanent(:in => RDF::ORA)
-    
+    map.comments(:to => "description", :in => RDF::DC)
+
   end
 
   accepts_nested_attributes_for :language

--- a/app/views/articles/_edit_detailed/_form.html.erb
+++ b/app/views/articles/_edit_detailed/_form.html.erb
@@ -197,6 +197,13 @@
         </div>
       </div>
 
+
+      <div class="content-box padding-0">
+          <div class="padding-25 no-pad-top no-pad-bottom">
+              <%= render partial: 'shared/comments', :locals => { :f => f, :@model => @article } %>
+          </div>
+      </div>
+
       <nav class="form-nav">
         <div class="form-nav-prev">
           <a href="#" class="button button-back light-blue" data-action="prev_step">Back</a>

--- a/app/views/articles/_edit_short/_form.html.erb
+++ b/app/views/articles/_edit_short/_form.html.erb
@@ -66,7 +66,14 @@
         </div>
       </div>
 
-      <!-- Form save and submit -->
+
+      <div class="content-box padding-0">
+          <div class="padding-25 no-pad-top no-pad-bottom">
+              <%= render partial: 'shared/comments', :locals => { :f => f, :@model => @article } %>
+          </div>
+      </div>
+
+              <!-- Form save and submit -->
       <nav class="form-nav" style="margin-top: 20px;">
         <div class="form-nav-next" style="text-align: right">
           <%= f.submit "Save", class: "button light-blue", :onclick => "setStatus(\"workflow_submit_entries_status\", \"default\")", data: {"submit-without-validation" => true} %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -36,6 +36,7 @@
 					<%= render partial: "admin_fields_show", :locals => { :article => @article } %>
 					<%= render partial: "shared/embargo/catalogue_fields_show", :locals => { :article => @article } %>
 					<%= render partial: "shared/workflow_show", :locals => { :article => @article } %>
+					<%= render partial: "shared/comments_show", :locals => { :@model => @article } %>
 					<% if can? :review, :all %>
 						<%= render partial: "shared/permissions_show", :locals => { :article => @article } %>
 					<% end %>

--- a/app/views/datasets/_form.html.erb
+++ b/app/views/datasets/_form.html.erb
@@ -227,7 +227,6 @@
         <div class="padding-25 no-pad-top no-pad-bottom">
           <%= render partial: 'shared/funding_activity_fields_edit', :locals => { :f => f, :funding => @dataset.funding, :required => true } %>
         </div>
-
       </div>
 
       <h2 class="blue-text" style="margin-top: 30px;">Optional fields</h2>
@@ -241,6 +240,12 @@
           <%= render partial: "shared/license_activity_fields_edit", :locals => { :f => f, :article => @dataset } %>
           <%= render partial: "shared/rights_activity_fields_edit", :locals => { :f => f, :article => @dataset } %>
         </div>
+      </div>
+
+      <div class="content-box padding-0">
+          <div class="padding-25 no-pad-top no-pad-bottom">
+              <%= render partial: 'shared/comments', :locals => { :f => f, :@model => @dataset } %>
+          </div>
       </div>
 
       <nav class="form-nav">

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -37,7 +37,8 @@
 					<%= render partial: "admin_fields_show", :locals => { :article => @dataset } %>
 					<%= render partial: "shared/embargo/catalogue_fields_show", :locals => { :article => @dataset } %>
 					<%= render partial: "shared/workflow_show", :locals => { :article => @dataset } %>
-                                        <% if can? :review, :all %>
+					<%= render partial: "shared/comments_show", :locals => { :@model => @dataset } %>
+					<% if can? :review, :all %>
 						<%= render partial: "shared/permissions_show", :locals => { :article => @dataset } %>
 					<% end %>
 				</div>

--- a/app/views/shared/_comments.html.erb
+++ b/app/views/shared/_comments.html.erb
@@ -1,8 +1,7 @@
 <h4>Additional information</h4>
 <%# if !@model.comments.nil? && !@model.comments.empty? %>
     <div class="fieldset">
-        <label>Comment</label>
-        <%= f.text_field :comments, :value => @model.comments.first, :id => "comments_description", data: {"progress" => "documentation"} %>
+        <%= f.text_area :comments, :value => @model.comments.first, :id => "comments_description", data: {"progress" => "documentation"} %>
         <%= render partial: '/shared/tooltip', :locals => {:tipType => "documentation" , :tipTitle => "Comment" , :tipDescription => "Here you can record a generic comment or add notes for future reference." } %>
     </div>
 <%# end %>

--- a/app/views/shared/_comments.html.erb
+++ b/app/views/shared/_comments.html.erb
@@ -1,0 +1,8 @@
+<h4>Additional information</h4>
+<%# if !@model.comments.nil? && !@model.comments.empty? %>
+    <div class="fieldset">
+        <label>Comment</label>
+        <%= f.text_field :comments, :value => @model.comments.first, :id => "comments_description", data: {"progress" => "documentation"} %>
+        <%= render partial: '/shared/tooltip', :locals => {:tipType => "documentation" , :tipTitle => "Comment" , :tipDescription => "Here you can record a generic comment or add notes for future reference." } %>
+    </div>
+<%# end %>

--- a/app/views/shared/_comments_show.html.erb
+++ b/app/views/shared/_comments_show.html.erb
@@ -1,0 +1,7 @@
+<div class="accordian">
+    <div class="accordian-header">Additional Information</div>
+    <div class="accordian-content">
+        <p><%=@model.comments.first %></p>
+    </div>
+</div>
+

--- a/app/views/shared/_file_info_fields_edit.html.erb
+++ b/app/views/shared/_file_info_fields_edit.html.erb
@@ -52,16 +52,6 @@
                         <% embargo_start = hp.accessRights[0].embargoDate[0].start[0].date[0] %>
                         &nbsp;&nbsp;&nbsp;&nbsp;Start: <%= embargo_start %>
                       <% end %>
-                      <% if not hp.accessRights[0].embargoDate[0].duration.empty? %>
-                        &nbsp;&nbsp;&nbsp;&nbsp;Duration[
-                        <% if not embargo_duration = hp.accessRights[0].embargoDate[0].duration[0].years.empty?%>
-                           Years:<%= embargo_duration %>
-                        <% end %>
-                        <% if not embargo_duration = hp.accessRights[0].embargoDate[0].duration[0].months.empty?%>
-                           Months:<%= embargo_duration %>
-                           ]
-                        <% end %>
-                      <% end %>
                       <% if not hp.accessRights[0].embargoDate[0].end.empty? %>
                         &nbsp;&nbsp;&nbsp;&nbsp;End:
                         <% embargo_end = hp.accessRights[0].embargoDate[0].end[0].date[0]%> <%= embargo_end %>

--- a/app/views/theses/_form.html.erb
+++ b/app/views/theses/_form.html.erb
@@ -158,13 +158,12 @@
         </div>
         <%= render partial: 'shared/file_info_fields_edit', :locals => { :f => f, :article => @thesis } %>
         <%= render partial: 'shared/embargo/embargo_fields_edit', :locals => { :f => f, :accessRights => @thesis.accessRights, :embargo_type => "metadata" } %>
+        <div class="padding-side-25">
+          <%= render partial: 'shared/comments', :locals => { :f => f, :@model => @thesis } %>
+        </div>
       </div>
-
-        <%= render partial: 'navigate', locals: { main_text: 'Continue to Step 7', sub_text: 'Review workflow' } %>
+          <%= render partial: 'navigate', locals: { main_text: 'Continue to Step 7', sub_text: 'Review workflow' } %>
     </section>
-
-
-
 
 
     <% if can? :review, :all %>

--- a/app/views/theses/show.html.erb
+++ b/app/views/theses/show.html.erb
@@ -34,6 +34,7 @@
           <%= render partial: "admin_fields_show", :locals => { :thesis => @thesis } %>
           <%= render partial: "shared/embargo/catalogue_fields_show", :locals => { :article => @thesis } %>
           <%= render partial: "shared/workflow_show", :locals => { :article => @thesis } %>
+          <%= render partial: "shared/comments_show", :locals => { :@model => @thesis } %>
           <% if can? :review, :all %>
               <%= render partial: "shared/permissions_show", :locals => { :article => @thesis } %>
           <% end %>


### PR DESCRIPTION
Trello ticket:
	https://trello.com/c/L0n1Dzrr/127-thesis-public-note-to-be-added-to-review-workflowe
 
Also , removed the 'Duration' from display that was most recently added under the 'Access condition for files' which would otherwise display 'false'(Boolean)

Fix:
	Added a new text field 'comment' to articles, datasets and theses with access being 'public'. (r/w acess for depositors/reviewers, and r access to public )

Also , removed the 'Duration' from display that was most recently added under the 'Access condition for files' which would otherwise display 'false'(Boolean). So we only display, the status of the file access, start and end embargo dates it applicable.

