### PR TITLE
"Continue to Step 7" is not being shown on step6 if logged in as depositor.

### DIFF
--- a/app/views/theses/_form.html.erb
+++ b/app/views/theses/_form.html.erb
@@ -162,7 +162,9 @@
           <%= render partial: 'shared/comments', :locals => { :f => f, :@model => @thesis } %>
         </div>
       </div>
+      <% if can? :review, :all %>
           <%= render partial: 'navigate', locals: { main_text: 'Continue to Step 7', sub_text: 'Review workflow' } %>
+      <% end %>
     </section>
 
 


### PR DESCRIPTION
Trello ticket:
	https://trello.com/c/J5W58M22/124-thesis-continue-to-step-7-showing-on-depositor-form

Fix:
	"Continue to Step 7" is not being shown on step6 if logged in as depositor( not reviewer ). Added a conditional check for the logged in user to be able to display the naviagation to the next step.