### PR TITLE
The openaccess access details needs to be checked by default for records

### DIFF
--- a/app/assets/javascripts/formUI.js
+++ b/app/assets/javascripts/formUI.js
@@ -95,6 +95,7 @@ function displayDoi() {
       $("#doiNote").show();
     }
     $('#dataset_accessRights_embargoStatus_open_access').trigger('click');
+    $('#dataset_accessRights_embargoStatus_open_access').prop('checked', true);
     $("#catalog_accessRights").hide();
   } else {
     $("#workflow_submit_involves_hidden").val('false');


### PR DESCRIPTION
The openaccess access details needs to be checked by default for records requesting doi registration