### PR TITLE
The openaccess access details needs to be checked by default for records requesting doi registration

### DIFF
--- a/app/assets/javascripts/formUI.js
+++ b/app/assets/javascripts/formUI.js
@@ -96,7 +96,6 @@ function displayDoi() {
     }
     $('#dataset_accessRights_embargoStatus_open_access').trigger('click');
     $('#dataset_accessRights_embargoStatus_open_access').prop('checked', true);
-    $("#catalog_accessRights").hide();
   } else {
     $("#workflow_submit_involves_hidden").val('false');
     $("#dataset_doi_fieldset").show();


### PR DESCRIPTION
The openaccess access details needs to be checked by default for records requesting doi registration