### PR TITLE
change to prevent infinite loop in Datacite resolve call

### DIFF
--- a/lib/doi_generator.rb
+++ b/lib/doi_generator.rb
@@ -17,7 +17,7 @@ module DoiGenerator
     raw_string = uuid.gsub("uuid:", "").gsub("-", "").slice(0, SLICE_DIGITS)
     doi = DOI_SHOULDER + ":" + hashids.encode_hex(raw_string)
     # make sure DOI not already on Datacite
-    generate unless MDS.resolve(doi).instance_of? Net::HTTPNotFound
+    generate if MDS.resolve(doi).instance_of? Net::HTTPOK
     doi
   end
 


### PR DESCRIPTION
previous implementation relied on receiving a 404 when doi couldn't be found on Datacite service. However, Datacite will sometimes return 302 (Redirect) before a 404, which confused our application logic.